### PR TITLE
Migrate assert to expect

### DIFF
--- a/tests/AbstractClassContentsTest.php
+++ b/tests/AbstractClassContentsTest.php
@@ -34,9 +34,8 @@ class AbstractClassContentsTest extends \PHPUnit_Framework_TestCase {
 
   public function testMethodsAreAbstract(): void {
     $class = $this->classes[0] ?? null;
-    $this->assertSame(
+    expect($class?->getName())->toBeSame(
       'Facebook\\DefinitionFinder\\Test\\AbstractClassWithContents',
-      $class?->getName(),
     );
     expect(Vec\map($class?->getMethods() ?? vec[], $x ==> $x->isAbstract()))
       ->toBeSame(vec[false, true], 'isAbstract');

--- a/tests/AbstractHackTest.php
+++ b/tests/AbstractHackTest.php
@@ -191,28 +191,28 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
 
   public function testFunctionReturnTypes(): void {
     $type = $this->getFunction('returns_int')->getReturnType();
-    $this->assertSame('int', $type?->getTypeName());
-    $this->assertEmpty($type?->getGenericTypes());
+    expect($type?->getTypeName())->toBeSame('int');
+    expect($type?->getGenericTypes())->toBeEmpty();
 
     $type = $this->getFunction('returns_generic')->getReturnType();
-    $this->assertSame('Vector', $type?->getTypeName());
+    expect($type?->getTypeName())->toBeSame('Vector');
     $generics = $type?->getGenericTypes();
-    $this->assertSame(1, count($generics));
+    expect(count($generics))->toBeSame(1);
     $sub_type = $generics[0] ?? null;
-    $this->assertSame('int', $sub_type?->getTypeName());
-    $this->assertEmpty($sub_type?->getGenericTypes());
+    expect($sub_type?->getTypeName())->toBeSame('int');
+    expect($sub_type?->getGenericTypes())->toBeEmpty();
 
     $type = $this->getFunction('returns_nested_generic')->getReturnType();
-    $this->assertSame('Vector', $type?->getTypeName());
+    expect($type?->getTypeName())->toBeSame('Vector');
     $generics = $type?->getGenericTypes();
-    $this->assertSame(1, count($generics));
+    expect(count($generics))->toBeSame(1);
     $sub_type = $generics[0] ?? null;
-    $this->assertSame('Vector', $sub_type?->getTypeName());
+    expect($sub_type?->getTypeName())->toBeSame('Vector');
     $sub_generics = $sub_type?->getGenericTypes();
-    $this->assertSame(1, count($sub_generics));
+    expect(count($sub_generics))->toBeSame(1);
     $sub_sub_type = $sub_generics[0] ?? null;
-    $this->assertSame('int', $sub_sub_type?->getTypeName());
-    $this->assertEmpty($sub_sub_type?->getGenericTypes());
+    expect($sub_sub_type?->getTypeName())->toBeSame('int');
+    expect($sub_sub_type?->getGenericTypes())->toBeEmpty();
   }
 
   public function testAliasedTypehints(): void {
@@ -229,8 +229,8 @@ abstract class AbstractHackTest extends PHPUnit_Framework_TestCase {
     foreach ($data as $typeName => $fun) {
       $returnType = $fun->getReturnType();
       $paramType = ($fun->getParameters()[0] ?? null)?->getTypehint();
-      $this->assertSame($typeName, $returnType?->getTypeName());
-      $this->assertSame($typeName, $paramType?->getTypeName());
+      expect($returnType?->getTypeName())->toBeSame($typeName);
+      expect($paramType?->getTypeName())->toBeSame($typeName);
     }
   }
 

--- a/tests/AliasingTest.php
+++ b/tests/AliasingTest.php
@@ -21,7 +21,7 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use MyOtherNamespace\\Foo;\n".
       'class Bar extends Foo {}';
     $def = FileParser::fromData($code)->getClass('MyNamespace\\Bar');
-    $this->assertSame("MyOtherNamespace\\Foo", $def->getParentClassName());
+    expect($def->getParentClassName())->toBeSame("MyOtherNamespace\\Foo");
   }
 
   public function testMultiUse(): void {
@@ -29,7 +29,7 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use Foo\\Bar, Herp\\Derp;\n".
       'class MyClass extends Bar implements Derp {}';
     $def = FileParser::fromData($code)->getClass('MyClass');
-    $this->assertSame("Foo\\Bar", $def->getParentClassName());
+    expect($def->getParentClassName())->toBeSame("Foo\\Bar");
     expect($def->getInterfaceNames())->toBeSame(vec["Herp\\Derp"]);
   }
 
@@ -39,7 +39,7 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use MyOtherNamespace\\Foo as SuperClass;\n".
       'class Bar extends SuperClass {}';
     $def = FileParser::fromData($code)->getClass('MyNamespace\\Bar');
-    $this->assertSame("MyOtherNamespace\\Foo", $def->getParentClassName());
+    expect($def->getParentClassName())->toBeSame("MyOtherNamespace\\Foo");
   }
 
   public function testMultiUseWithClassAlias(): void {
@@ -47,7 +47,7 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use Foo\\Bar as Baz, Herp\\Derp;\n".
       'class MyClass extends Baz implements Derp {}';
     $def = FileParser::fromData($code)->getClass('MyClass');
-    $this->assertSame("Foo\\Bar", $def->getParentClassName());
+    expect($def->getParentClassName())->toBeSame("Foo\\Bar");
     expect($def->getInterfaceNames())->toBeSame(vec["Herp\\Derp"]);
   }
 
@@ -57,7 +57,7 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use MyOtherNamespace as OtherNS;\n".
       "class Bar extends OtherNS\\Foo{}";
     $def = FileParser::fromData($code)->getClass('MyNamespace\\Bar');
-    $this->assertSame("MyOtherNamespace\\Foo", $def->getParentClassName());
+    expect($def->getParentClassName())->toBeSame("MyOtherNamespace\\Foo");
   }
 
   public function testSimpleGroupUse(): void {
@@ -117,9 +117,8 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use MyOtherNamespace\\Foo;\n".
       "function my_func(): Foo {}";
     $def = FileParser::fromData($code)->getFunction('MyNamespace\\my_func');
-    $this->assertSame(
+    expect($def->getReturnType()?->getTypeName())->toBeSame(
       "MyOtherNamespace\\Foo",
-      $def->getReturnType()?->getTypeName(),
     );
   }
 
@@ -129,10 +128,7 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use function MyOtherNamespace\\Foo;\n".
       "function my_func(): Foo {}";
     $def = FileParser::fromData($code)->getFunction('MyNamespace\\my_func');
-    $this->assertSame(
-      "MyNamespace\\Foo",
-      $def->getReturnType()?->getTypeName(),
-    );
+    expect($def->getReturnType()?->getTypeName())->toBeSame("MyNamespace\\Foo");
   }
 
   public function testConstUseIsNotTypeAlias(): void {
@@ -141,10 +137,7 @@ final class AliasingTest extends \PHPUnit_Framework_TestCase {
       "use const MyOtherNamespace\\Foo;\n".
       "function my_func(): Foo {}";
     $def = FileParser::fromData($code)->getFunction('MyNamespace\\my_func');
-    $this->assertSame(
-      "MyNamespace\\Foo",
-      $def->getReturnType()?->getTypeName(),
-    );
+    expect($def->getReturnType()?->getTypeName())->toBeSame("MyNamespace\\Foo");
   }
 
   public function testFunctionAndConstGroupUseIsNotTypeAlias(): void {

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -64,7 +64,7 @@ class AttributesTest extends \PHPUnit_Framework_TestCase {
     $class = $this->findClass('ClassWithIntAttribute');
     expect($class->getAttributes())->toBeSame(dict['Herp' => vec[123]]);
     // Check it's an int, not a string
-    $this->assertSame(123, $class->getAttributes()['Herp'][0]);
+    expect($class->getAttributes()['Herp'][0])->toBeSame(123);
   }
 
   public function testFunctionHasAttributes(): void {
@@ -76,7 +76,7 @@ class AttributesTest extends \PHPUnit_Framework_TestCase {
     $data = '<?hh function foo() { 1 << 3; }';
     $parser = FileParser::fromData($data);
     $fun = $parser->getFunction('foo');
-    $this->assertEmpty($fun->getAttributes());
+    expect($fun->getAttributes())->toBeEmpty();
   }
 
   public function testPseudmainContainingBitShift(): void {

--- a/tests/ClassContentsTest.php
+++ b/tests/ClassContentsTest.php
@@ -21,21 +21,18 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
   protected function setUp(): void {
     $parser = FileParser::fromFile(__DIR__.'/data/class_contents.php');
     $this->class = $parser->getClasses()[0];
-    $this->assertSame(
+    expect($this->class->getName())->toBeSame(
       'Facebook\\DefinitionFinder\\Test\\ClassWithContents',
-      $this->class->getName(),
     );
   }
 
   public function testAnonymousClasses(): void {
     $parser = FileParser::fromFile(__DIR__.'/data/class_contents_php.php');
-    $this->assertEmpty(
-      $parser->getFunctions(),
+    expect($parser->getFunctions())->toBeEmpty(
       'Should be no functions - probably interpreting a method as a function',
     );
-    $this->assertSame(
+    expect(C\count($parser->getClasses()))->toBeSame(
       1,
-      C\count($parser->getClasses()),
       'The anonymous class should not be returned',
     );
     $class = $parser->getClass('ClassUsingAnonymousClass');
@@ -225,9 +222,9 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $constants = $parser->getClass('Foo')->getTypeConstants();
     $constant = C\onlyx($constants);
 
-    $this->assertSame('BAR', $constant->getName());
-    $this->assertFalse($constant->isAbstract());
-    $this->assertSame('int', $constant->getAliasedType()?->getTypeText());
+    expect($constant->getName())->toBeSame('BAR');
+    expect($constant->isAbstract())->toBeFalse();
+    expect($constant->getAliasedType()?->getTypeText())->toBeSame('int');
   }
 
   public function testClassAsTypeConstant(): void {
@@ -257,9 +254,9 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $constants = $parser->getClass('Foo')->getTypeConstants();
     $constant = C\onlyx($constants);
 
-    $this->assertSame('BAR', $constant->getName());
-    $this->assertFalse($constant->isAbstract());
-    $this->assertSame('int', $constant->getAliasedType()?->getTypeText());
+    expect($constant->getName())->toBeSame('BAR');
+    expect($constant->isAbstract())->toBeFalse();
+    expect($constant->getAliasedType()?->getTypeText())->toBeSame('int');
   }
 
   public function testAbstractConstant(): void {
@@ -267,9 +264,9 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $constant = C\onlyx($parser->getClass('Foo')->getConstants());
 
-    $this->assertSame('BAR', $constant->getName());
-    $this->assertTrue($constant->isAbstract());
-    $this->assertFalse($constant->hasValue());
+    expect($constant->getName())->toBeSame('BAR');
+    expect($constant->isAbstract())->toBeTrue();
+    expect($constant->hasValue())->toBeFalse();
   }
 
 
@@ -278,9 +275,9 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $constant = C\onlyx($parser->getClass('Foo')->getTypeConstants());
 
-    $this->assertSame('BAR', $constant->getName());
-    $this->assertTrue($constant->isAbstract());
-    $this->assertNull($constant->getAliasedType());
+    expect($constant->getName())->toBeSame('BAR');
+    expect($constant->isAbstract())->toBeTrue();
+    expect($constant->getAliasedType())->toBeNull();
   }
 
   public function testConstrainedAbstractTypeConstant(): void {
@@ -288,9 +285,9 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $constant = C\onlyx($parser->getClass('Foo')->getTypeConstants());
 
-    $this->assertSame('BAR', $constant->getName());
-    $this->assertTrue($constant->isAbstract());
-    $this->assertSame('Bar', $constant->getAliasedType()?->getTypeText());
+    expect($constant->getName())->toBeSame('BAR');
+    expect($constant->isAbstract())->toBeTrue();
+    expect($constant->getAliasedType()?->getTypeText())->toBeSame('Bar');
   }
 
   public function testTypeConstantAsProperty(): void {
@@ -298,8 +295,8 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $prop = C\onlyx($parser->getClass('Foo')->getProperties());
 
-    $this->assertSame('this::FOO', $prop->getTypehint()?->getTypeText());
-    $this->assertSame('foo', $prop->getName());
+    expect($prop->getTypehint()?->getTypeText())->toBeSame('this::FOO');
+    expect($prop->getName())->toBeSame('foo');
   }
 
   public function testTypeconstantAsReturnType(): void {
@@ -307,7 +304,7 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $method = C\onlyx($parser->getClass('Foo')->getMethods());
 
-    $this->assertSame('this::FOO', $method->getReturnType()?->getTypeText());
+    expect($method->getReturnType()?->getTypeText())->toBeSame('this::FOO');
   }
 
   public function testTypeconstantAsParameterType(): void {
@@ -316,8 +313,8 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $method = C\onlyx($parser->getClass('Foo')->getMethods());
     $param = C\onlyx($method->getParameters());
 
-    $this->assertSame('this::FOO', $param->getTypehint()?->getTypeText());
-    $this->assertSame('foo', $param->getName());
+    expect($param->getTypehint()?->getTypeText())->toBeSame('this::FOO');
+    expect($param->getName())->toBeSame('foo');
   }
 
   public static function namespacedReturns(
@@ -384,9 +381,8 @@ class ClassContentsTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $method = C\onlyx($parser->getClass($className)->getMethods());
 
-    $this->assertSame(
+    expect($method->getReturnType()?->getTypeText())->toBeSame(
       $expectedTypehintText,
-      $method->getReturnType()?->getTypeText(),
     );
   }
 }

--- a/tests/ConstructorPromotionTest.php
+++ b/tests/ConstructorPromotionTest.php
@@ -37,14 +37,14 @@ class Foo {
 
   public function testFoundMethods(): void {
     $meths = $this->class?->getMethods();
-    $this->assertSame(1, \count($meths));
+    expect(\count($meths))->toBeSame(1);
   }
 
   public function testConstructorParameters(): void {
     $meths = $this->class?->getMethods() ?? vec[];
     $constructors = Vec\filter($meths, $x ==> $x->getName() === '__construct');
     $constructor = $constructors[0] ?? null;
-    $this->assertNotNull($constructor, 'did not find constructor');
+    expect($constructor)->toNotBeNull('did not find constructor');
     assert($constructor instanceof ScannedMethod);
 
 

--- a/tests/CurlyTest.php
+++ b/tests/CurlyTest.php
@@ -38,7 +38,7 @@ final class CurlyTest extends PHPUnit_Framework_TestCase {
         break;
       }
     }
-    $this->assertTrue($matched, 'no T_CURLY_OPEN in data file');
+    expect($matched)->toBeTrue('no T_CURLY_OPEN in data file');
   }
 
   // Actually testing the tokenizer hasn't changed
@@ -51,7 +51,7 @@ final class CurlyTest extends PHPUnit_Framework_TestCase {
         break;
       }
     }
-    $this->assertTrue($matched, 'no T_DOLLAR_OPEN_CURLY_BRACES in data file');
+    expect($matched)->toBeTrue('no T_DOLLAR_OPEN_CURLY_BRACES in data file');
   }
 
   // Actually testing the tokenizer hasn't changed
@@ -61,8 +61,7 @@ final class CurlyTest extends PHPUnit_Framework_TestCase {
       if (!is_array($token)) {
         continue;
       }
-      $this->assertTrue(
-        $token[1] !== '}',
+      expect($token[1] !== '}')->toBeTrue(
         sprintf(
           'Got a token of type %d (%s) containing "}"',
           $token[0],

--- a/tests/DocCommentTest.php
+++ b/tests/DocCommentTest.php
@@ -38,37 +38,37 @@ class DocCommentTest extends \PHPUnit_Framework_TestCase {
 
   public function testClassWithDoc(): void {
     $def = $this->getDef('ClassWithDocComment');
-    $this->assertSame('/** class doc */', $def->getDocComment());
+    expect($def->getDocComment())->toBeSame('/** class doc */');
   }
 
   public function testClassWithoutDoc(): void {
     $def = $this->getDef('ClassWithoutDocComment');
-    $this->assertNull($def->getDocComment());
+    expect($def->getDocComment())->toBeNull();
   }
 
   public function testFunctionWithDoc(): void {
     $def = $this->getDef('function_with_doc_comment');
-    $this->assertSame('/** function doc */', $def->getDocComment());
+    expect($def->getDocComment())->toBeSame('/** function doc */');
   }
 
   public function testFunctionWithoutDoc(): void {
     $def = $this->getDef('function_without_doc_comment');
-    $this->assertNull($def->getDocComment());
+    expect($def->getDocComment())->toBeNull();
   }
 
   public function testTypeWithDoc(): void {
     $def = $this->getDef('TypeWithDocComment');
-    $this->assertSame('/** type doc */', $def->getDocComment());
+    expect($def->getDocComment())->toBeSame('/** type doc */');
   }
 
   public function testNewtypeWithDoc(): void {
     $def = $this->getDef('NewtypeWithDocComment');
-    $this->assertSame('/** newtype doc */', $def->getDocComment());
+    expect($def->getDocComment())->toBeSame('/** newtype doc */');
   }
 
   public function testEnumWithDoc(): void {
     $def = $this->getDef('EnumWithDocComment');
-    $this->assertSame('/** enum doc */', $def->getDocComment());
+    expect($def->getDocComment())->toBeSame('/** enum doc */');
   }
 
   public function testParameterWithDoc(): void {

--- a/tests/EndClosingTagTest.php
+++ b/tests/EndClosingTagTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class EndClosingTagTest extends AbstractPHPTest {
   <<__Override>>
   protected function getFilename(): string {

--- a/tests/FunctionNotDefinitionTest.php
+++ b/tests/FunctionNotDefinitionTest.php
@@ -41,8 +41,8 @@ EOF
     expect($p->getFunctionNames())->toBeSame(vec['foo']);
     $rt = $p->getFunction('foo')->getReturnType();
 
-    $this->assertSame('callable', $rt?->getTypeName());
-    $this->assertSame('(function():void)', $rt?->getTypeText());
+    expect($rt?->getTypeName())->toBeSame('callable');
+    expect($rt?->getTypeText())->toBeSame('(function():void)');
   }
 
   public function testReturnsGenericCallable(): void {
@@ -51,8 +51,8 @@ EOF
     expect($p->getFunctionNames())->toBeSame(vec['foo']);
 
     $rt = $p->getFunction('foo')->getReturnType();
-    $this->assertSame('callable', $rt?->getTypeName());
-    $this->assertSame('(function():vec<string>)', $rt?->getTypeText());
+    expect($rt?->getTypeName())->toBeSame('callable');
+    expect($rt?->getTypeText())->toBeSame('(function():vec<string>)');
   }
 
   public function testAsParameterType(): void {
@@ -86,6 +86,6 @@ EOF
 
   public function testAsRVal(): void {
     $p = FileParser::fromData('<?php $f = function(){};');
-    $this->assertEmpty($p->getFunctionNames());
+    expect($p->getFunctionNames())->toBeEmpty();
   }
 }

--- a/tests/GenericsTest.php
+++ b/tests/GenericsTest.php
@@ -138,9 +138,8 @@ class GenericsTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $function = $parser->getFunction('foo');
     $generics = $function->getGenericTypes();
-    $this->assertSame(
+    expect($generics[0]->getConstraints()[0]['type']->getTypeText())->toBeSame(
       'shape()',
-      $generics[0]->getConstraints()[0]['type']->getTypeText(),
     );
   }
 

--- a/tests/MixedPHPAndHTMLTest.php
+++ b/tests/MixedPHPAndHTMLTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class MixedPHPAndHTMLTest extends AbstractPHPTest {
   <<__Override>>
   protected function getFilename(): string {

--- a/tests/NamingTest.php
+++ b/tests/NamingTest.php
@@ -21,7 +21,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
 
     // Check that it parses
     $parser = FileParser::fromData($data);
-    $this->assertNotNull($parser->getFunction('select'));
+    expect($parser->getFunction('select'))->toNotBeNull();
   }
 
   /** Things that are valid names, but have a weird token type */
@@ -45,7 +45,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $data = '<?php function foo(): '.$type.' {}';
     $parser = FileParser::fromData($data);
     $func = $parser->getFunction('foo');
-    $this->assertSame($type, $func->getReturnType()?->getTypeName());
+    expect($func->getReturnType()?->getTypeName())->toBeSame($type);
   }
 
   /** @dataProvider specialNameProvider */
@@ -53,8 +53,8 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $data = '<?php function '.$type.'(): void {}';
     $parser = FileParser::fromData($data);
     $func = $parser->getFunction($type);
-    $this->assertSame('void', $func->getReturnType()?->getTypeName());
-    $this->assertSame($type, $func->getName());
+    expect($func->getReturnType()?->getTypeName())->toBeSame('void');
+    expect($func->getName())->toBeSame($type);
   }
 
   /** @dataProvider specialNameProvider */
@@ -62,7 +62,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $data = '<?php class '.$type.' { }';
     $parser = FileParser::fromData($data);
     $class = $parser->getClass($type);
-    $this->assertNotNull($class);
+    expect($class)->toNotBeNull();
   }
 
   /** @dataProvider specialNameProvider */
@@ -70,7 +70,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $data = '<?php namespace '.$type.' { class Foo {} }';
     $parser = FileParser::fromData($data);
     $class = $parser->getClass($type."\\Foo");
-    $this->assertNotNull($class);
+    expect($class)->toNotBeNull();
   }
 
   /** @dataProvider specialNameProvider */
@@ -78,7 +78,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $data = '<?php use Foo\\'.$type.'; class Herp extends '.$type.' { }';
     $parser = FileParser::fromData($data);
     $class = $parser->getClass('Herp');
-    $this->assertNotNull($class);
+    expect($class)->toNotBeNull();
   }
 
   /** @dataProvider specialNameProvider */
@@ -86,7 +86,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $data = '<?php use Foo\\Bar as '.$type.'; class Herp extends '.$type.' { }';
     $parser = FileParser::fromData($data);
     $class = $parser->getClass('Herp');
-    $this->assertNotNull($class);
+    expect($class)->toNotBeNull();
   }
 
   /**
@@ -201,8 +201,8 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $php_class = FileParser::fromData($php)->getClass("Foo\\MyClass");
     $hack_class = FileParser::fromData($hack)->getClass("Foo\\MyClass");
 
-    $this->assertSame("Foo\\Collection", $php_class->getParentClassName());
-    $this->assertSame('Collection', $hack_class->getParentClassName());
+    expect($php_class->getParentClassName())->toBeSame("Foo\\Collection");
+    expect($hack_class->getParentClassName())->toBeSame('Collection');
   }
 
   public function testScalarParameterInNamespace(): void {
@@ -227,7 +227,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($code);
     $class = $parser->getClass("Foo\\MyClass");
     $method = $class->getMethods()[0];
-    $this->assertSame('this', $method->getReturnType()?->getTypeName());
+    expect($method->getReturnType()?->getTypeName())->toBeSame('this');
   }
 
   public function testReturnsClassGenericInNamespace(): void {
@@ -239,7 +239,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($code);
     $class = $parser->getClass("Foo\\MyClass");
     $method = $class->getMethods()[0];
-    $this->assertSame('T', $method->getReturnType()?->getTypeName());
+    expect($method->getReturnType()?->getTypeName())->toBeSame('T');
   }
 
   public function testReturnsNullableClassGenericInNamespace(): void {
@@ -251,8 +251,8 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($code);
     $class = $parser->getClass("Foo\\MyClass");
     $method = $class->getMethods()[0];
-    $this->assertSame('T', $method->getReturnType()?->getTypeName());
-    $this->assertTrue($method->getReturnType()?->isNullable());
+    expect($method->getReturnType()?->getTypeName())->toBeSame('T');
+    expect($method->getReturnType()?->isNullable())->toBeTrue();
   }
 
   public function testReturnsMethodGenericInNamespace(): void {
@@ -264,7 +264,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($code);
     $class = $parser->getClass("Foo\\MyClass");
     $method = $class->getMethods()[0];
-    $this->assertSame('T', $method->getReturnType()?->getTypeName());
+    expect($method->getReturnType()?->getTypeName())->toBeSame('T');
   }
 
   /**
@@ -281,14 +281,9 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($code);
     $class = $parser->getClass("Foo\\MyClass");
     $method = $class->getMethods()[0];
-    $this->assertSame(
-      'TClassGeneric',
-      $method->getReturnType()?->getTypeName(),
-    );
-    $this->assertSame(
-      'TFunctionGeneric',
-      $method->getParameters()[0]->getTypehint()?->getTypeName(),
-    );
+    expect($method->getReturnType()?->getTypeName())->toBeSame('TClassGeneric');
+    expect($method->getParameters()[0]->getTypehint()?->getTypeName())
+      ->toBeSame('TFunctionGeneric');
   }
 
   public function testTakesMethodGenericInNamespace(): void {
@@ -300,9 +295,7 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($code);
     $class = $parser->getClass("Foo\\MyClass");
     $method = $class->getMethods()[0];
-    $this->assertSame(
-      'T',
-      $method->getParameters()[0]->getTypehint()?->getTypeName(),
-    );
+    expect($method->getParameters()[0]->getTypehint()?->getTypeName())
+      ->toBeSame('T');
   }
 }

--- a/tests/NestedNamespaceHackTest.php
+++ b/tests/NestedNamespaceHackTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class NestedNamespaceHackTest extends AbstractHackTest {
   <<__Override>>
   protected function getFilename(): string {

--- a/tests/NestedNamespacePHPTest.php
+++ b/tests/NestedNamespacePHPTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class NestedNamespacePHPTest extends AbstractPHPTest {
   <<__Override>>
   protected function getFilename(): string {

--- a/tests/NoNamespaceHackTest.php
+++ b/tests/NoNamespaceHackTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class NoNamespaceHackTest extends AbstractHackTest {
   <<__Override>>
   protected function getFilename(): string {

--- a/tests/NoNamespacePHPTest.php
+++ b/tests/NoNamespacePHPTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class NoNamespacePHPTest extends AbstractPHPTest {
   <<__Override>>
   protected function getFilename(): string {

--- a/tests/ParametersTest.php
+++ b/tests/ParametersTest.php
@@ -29,11 +29,11 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
 
     $params = $function->getParameters();
 
-    $this->assertSame(2, \count($params));
-    $this->assertSame('bar', $params[0]->getName());
-    $this->assertSame('baz', $params[1]->getName());
-    $this->assertNull($params[0]->getTypehint());
-    $this->assertNull($params[1]->getTypehint());
+    expect(\count($params))->toBeSame(2);
+    expect($params[0]->getName())->toBeSame('bar');
+    expect($params[1]->getName())->toBeSame('baz');
+    expect($params[0]->getTypehint())->toBeNull();
+    expect($params[1]->getTypehint())->toBeNull();
   }
 
   public function testWithSimpleType(): void {
@@ -43,12 +43,12 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
     $function = $parser->getFunction('foo');
 
     $params = $function->getParameters();
-    $this->assertSame(1, \count($params));
+    expect(\count($params))->toBeSame(1);
     $param = $params[0];
-    $this->assertSame('bar', $param->getName());
+    expect($param->getName())->toBeSame('bar');
     $typehint = $param->getTypehint();
-    $this->assertSame('string', $typehint?->getTypeName());
-    $this->assertEmpty($typehint?->getGenericTypes());
+    expect($typehint?->getTypeName())->toBeSame('string');
+    expect($typehint?->getGenericTypes())->toBeEmpty();
   }
 
   public function testWithDefault(): void {
@@ -77,7 +77,8 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
 
   public function testWithNullDefault(): void {
     $data = '<?hh function foo($bar, $baz = null) {}';
-    $parameters = FileParser::fromData($data)->getFunction('foo')->getParameters();
+    $parameters =
+      FileParser::fromData($data)->getFunction('foo')->getParameters();
     list($bar, $baz) = $parameters;
     expect($bar->getDefault())->toBeNull();
     $default = expect($baz->getDefault())->toNotBeNull();
@@ -163,10 +164,8 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
     expect(Vec\map($function->getParameters(), $x ==> $x->getName()))->toBeSame(
       vec['bar'],
     );
-    $this->assertSame(
-      'Iterator',
-      $function->getParameters()[0]->getTypehint()?->getTypeName(),
-    );
+    expect($function->getParameters()[0]->getTypehint()?->getTypeName())
+      ->toBeSame('Iterator');
   }
 
   public function testWithNamespacedType(): void {
@@ -178,10 +177,8 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
     expect(Vec\map($function->getParameters(), $x ==> $x->getName()))->toBeSame(
       vec['bar'],
     );
-    $this->assertSame(
-      'Foo\\Bar',
-      $function->getParameters()[0]->getTypehint()?->getTypeName(),
-    );
+    expect($function->getParameters()[0]->getTypehint()?->getTypeName())
+      ->toBeSame('Foo\\Bar');
   }
 
   public function testWithLegacyCallableType(): void {
@@ -193,10 +190,8 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
     expect(Vec\map($function->getParameters(), $x ==> $x->getName()))->toBeSame(
       vec['bar'],
     );
-    $this->assertSame(
-      'callable',
-      $function->getParameters()[0]->getTypehint()?->getTypeName(),
-    );
+    expect($function->getParameters()[0]->getTypehint()?->getTypeName())
+      ->toBeSame('callable');
   }
 
   public function testWithByRefParam(): void {
@@ -245,7 +240,7 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
     expect(Vec\map($function->getParameters(), $x ==> $x->getName()))->toBeSame(
       vec['bar'],
     );
-    $this->assertNull($function->getParameters()[0]->getTypehint());
+    expect($function->getParameters()[0]->getTypehint())->toBeNull();
   }
 
   public function testWithUntypedVariadicParam(): void {
@@ -298,8 +293,8 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $type = $parser->getFunction('foo')->getParameters()[0]->getTypehint();
 
-    $this->assertSame('callable', $type?->getTypeName());
-    $this->assertSame('(function(int):string)', $type?->getTypeText());
+    expect($type?->getTypeName())->toBeSame('callable');
+    expect($type?->getTypeText())->toBeSame('(function(int):string)');
   }
 
   public function testEmptyShapeTypehint(): void {
@@ -307,8 +302,8 @@ class ParameterTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     $type = $parser->getFunction('foo')->getParameters()[0]->getTypehint();
 
-    $this->assertSame('shape', $type?->getTypeName());
-    $this->assertSame('shape()', $type?->getTypeText());
+    expect($type?->getTypeName())->toBeSame('shape');
+    expect($type?->getTypeText())->toBeSame('shape()');
   }
 
   public function testNonNullableTypehint(): void {

--- a/tests/RelationshipsTest.php
+++ b/tests/RelationshipsTest.php
@@ -18,36 +18,36 @@ class RelationshipsTest extends \PHPUnit_Framework_TestCase {
   public function testClassExtends(): void {
     $data = '<?hh class Foo extends Bar {}';
     $def = FileParser::fromData($data)->getClass('Foo');
-    $this->assertSame('Bar', $def->getParentClassName());
-    $this->assertEmpty($def->getInterfaceNames());
+    expect($def->getParentClassName())->toBeSame('Bar');
+    expect($def->getInterfaceNames())->toBeEmpty();
   }
 
   public function testClassImplements(): void {
     $data = '<?hh class Foo implements Bar, Baz {}';
     $def = FileParser::fromData($data)->getClass('Foo');
     expect($def->getInterfaceNames())->toBeSame(vec['Bar', 'Baz']);
-    $this->assertNull($def->getParentClassName());
+    expect($def->getParentClassName())->toBeNull();
   }
 
   public function testInterfaceExtends(): void {
     $data = '<?hh interface Foo extends Bar, Baz {}';
     $def = FileParser::fromData($data)->getInterface('Foo');
     expect($def->getInterfaceNames())->toBeSame(vec['Bar', 'Baz']);
-    $this->assertNull($def->getParentClassName());
+    expect($def->getParentClassName())->toBeNull();
   }
 
   public function testClassExtendsAndImplements(): void {
     $data = '<?hh class Foo extends Bar implements Herp, Derp {}';
     $def = FileParser::fromData($data)->getClass('Foo');
-    $this->assertSame('Bar', $def->getParentClassName());
+    expect($def->getParentClassName())->toBeSame('Bar');
     expect($def->getInterfaceNames())->toBeSame(vec['Herp', 'Derp']);
   }
 
   public function testClassExtendsGeneric(): void {
     $data = '<?hh class Foo extends Bar<Baz> {}';
     $def = FileParser::fromData($data)->getClass('Foo');
-    $this->assertSame('Bar', $def->getParentClassName());
-    $this->assertSame('Bar<Baz>', $def->getParentClassInfo()?->getTypeText());
+    expect($def->getParentClassName())->toBeSame('Bar');
+    expect($def->getParentClassInfo()?->getTypeText())->toBeSame('Bar<Baz>');
   }
 
   public function testClassImplementsGenerics(): void {

--- a/tests/SelfTest.php
+++ b/tests/SelfTest.php
@@ -11,6 +11,7 @@
 namespace Facebook\DefinitionFinder\Test;
 
 use type Facebook\DefinitionFinder\FileParser;
+use function Facebook\FBExpect\expect;
 
 class SelfTest extends \PHPUnit_Framework_TestCase {
 
@@ -28,6 +29,6 @@ class SelfTest extends \PHPUnit_Framework_TestCase {
    */
   public function testSelf(string $_, string $filename): void {
     $parser = FileParser::fromFile($filename);
-    $this->assertNotNull($parser);
+    expect($parser)->toNotBeNull();
   }
 }

--- a/tests/SingleNamespacePHPTest.php
+++ b/tests/SingleNamespacePHPTest.php
@@ -8,6 +8,8 @@
  *
  */
 
+use function Facebook\FBExpect\expect;
+
 class SingleNamespacePHPTest extends AbstractPHPTest {
   <<__Override>>
   protected function getFilename(): string {

--- a/tests/SourceTypeTest.php
+++ b/tests/SourceTypeTest.php
@@ -11,6 +11,7 @@
 namespace Facebook\DefinitionFinder\Tests;
 
 use type Facebook\DefinitionFinder\FileParser;
+use function Facebook\FBExpect\expect;
 use type Facebook\DefinitionFinder\SourceType;
 
 class SourceTypeTest extends \PHPUnit_Framework_TestCase {
@@ -37,15 +38,15 @@ class SourceTypeTest extends \PHPUnit_Framework_TestCase {
   ): void {
     $code = $prefix."\nclass Foo {}";
     $parser = FileParser::fromData($code);
-    $this->assertSame($expected, $parser->getClass('Foo')->getSourceType());
+    expect($parser->getClass('Foo')->getSourceType())->toBeSame($expected);
   }
 
   public function testPlainTextFileParses(): void {
     $parser = FileParser::fromData('foo');
-    $this->assertEmpty($parser->getClasses());
-    $this->assertEmpty($parser->getFunctions());
-    $this->assertEmpty($parser->getTypes());
-    $this->assertEmpty($parser->getNewtypes());
-    $this->assertEmpty($parser->getConstants());
+    expect($parser->getClasses())->toBeEmpty();
+    expect($parser->getFunctions())->toBeEmpty();
+    expect($parser->getTypes())->toBeEmpty();
+    expect($parser->getNewtypes())->toBeEmpty();
+    expect($parser->getConstants())->toBeEmpty();
   }
 }

--- a/tests/TypehintTest.php
+++ b/tests/TypehintTest.php
@@ -11,6 +11,7 @@
 namespace Facebook\DefinitionFinder\Tests;
 
 use type Facebook\DefinitionFinder\FileParser;
+use function Facebook\FBExpect\expect;
 
 final class TypeHintTest extends \PHPUnit_Framework_TestCase {
   public function provideTypesInNamespace(): array<(string, string, string)> {
@@ -65,9 +66,9 @@ final class TypeHintTest extends \PHPUnit_Framework_TestCase {
       " \$_): void {}\n";
     $def = FileParser::fromData($code)->getFunction('MyNamespace\\main');
     $type = $def->getParameters()[0]->getTypehint();
-    $this->assertNotNull($type);
-    $this->assertSame($name, $type?->getTypeName(), 'type name differs');
-    $this->assertSame($text, $type?->getTypeText(), 'type text differs');
+    expect($type)->toNotBeNull();
+    expect($type?->getTypeName())->toBeSame($name, 'type name differs');
+    expect($type?->getTypeText())->toBeSame($text, 'type text differs');
   }
 
   public function provideNullableExamples(
@@ -99,9 +100,9 @@ final class TypeHintTest extends \PHPUnit_Framework_TestCase {
     $code = "<?hh \n"."function main(".$input." \$_): void {}\n";
     $def = FileParser::fromData($code)->getFunction('main');
     $type = $def->getParameters()[0]->getTypehint();
-    $this->assertNotNull($type);
-    $this->assertSame($nullable, $type?->isNullable(), 'nullability differs');
-    $this->assertSame($name, $type?->getTypeName(), 'type name differs');
-    $this->assertSame($text, $type?->getTypeText(), 'type text differs');
+    expect($type)->toNotBeNull();
+    expect($type?->isNullable())->toBeSame($nullable, 'nullability differs');
+    expect($type?->getTypeName())->toBeSame($name, 'type name differs');
+    expect($type?->getTypeText())->toBeSame($text, 'type text differs');
   }
 }

--- a/tests/XHPTest.php
+++ b/tests/XHPTest.php
@@ -28,8 +28,8 @@ final class XHPTest extends \PHPUnit_Framework_TestCase {
     $function = $parser->getFunction('foo');
     $ret = $function->getReturnType();
     $ret = expect($ret)->toNotBeNull();
-    $this->assertSame('xhp_foo__bar', $ret->getTypeName());
-    $this->assertTrue($ret->isNullable());
+    expect($ret->getTypeName())->toBeSame('xhp_foo__bar');
+    expect($ret->isNullable())->toBeTrue();
   }
 
   public function testXHPClassWithParent(): void {
@@ -38,9 +38,8 @@ final class XHPTest extends \PHPUnit_Framework_TestCase {
     $parser = FileParser::fromData($data);
     expect($parser->getClassNames())->toContain('xhp_foo__bar');
 
-    $this->assertSame(
+    expect($parser->getClass('xhp_foo__bar')->getParentClassName())->toBeSame(
       'xhp_herp__derp',
-      $parser->getClass('xhp_foo__bar')->getParentClassName(),
     );
   }
 
@@ -70,9 +69,8 @@ EOF;
   public function testXHPClassNamesAreCorrect(): void {
     $parser = FileParser::fromData('<?hh class :foo:bar:baz:herp-derp {}');
 
-    $this->assertContains(
+    expect(C\onlyx($parser->getClassNames()))->toContain(
       /* UNSAFE_EXPR */ :foo:bar:baz:herp-derp::class,
-      C\onlyx($parser->getClassNames()),
     );
   }
 }


### PR DESCRIPTION
- All tests are passing as before the migration
- There are a few instances of plain PHP assert (not PHPUnit assertFoo)