### PR TITLE
Add type hints to lambda parameters.

### DIFF
--- a/src/consumers/classish_from_ast.hack
+++ b/src/consumers/classish_from_ast.hack
@@ -48,7 +48,9 @@ function classish_from_ast<T as ScannedClassish>(
   }
 
   $modifiers = $node->getModifiers() ?? new HHAST\EditableList(vec[]);
-  $has_modifier = $m ==> !C\is_empty($modifiers->getItemsOfType($m));
+  $has_modifier = (
+    classname<HHAST\EditableNode> $m
+  ) ==> !C\is_empty($modifiers->getItemsOfType($m));
 
   $generics = generics_from_ast($context, $node->getTypeParameters());
   $context['genericTypeNames'] = Keyset\union(

--- a/src/consumers/method_from_ast.hack
+++ b/src/consumers/method_from_ast.hack
@@ -20,7 +20,9 @@ function method_from_ast(
 
   $header = $node->getFunctionDeclHeader();
   $modifiers = $header->getModifiers() ?? (new HHAST\EditableList(vec[]));
-  $has_modifier = $m ==> !C\is_empty($modifiers->getItemsOfType($m));
+  $has_modifier = (
+    classname<HHAST\EditableNode> $m
+  ) ==> !C\is_empty($modifiers->getItemsOfType($m));
 
   $generics = generics_from_ast($context, $header->getTypeParameterList());
   $context['genericTypeNames'] = Keyset\union(


### PR DESCRIPTION
Summary: required for .hhconfig disallow_ambiguous_lambda.

Signed-off-by: Arthur Loiret <arthur.loiret@emerton-data.com>