### PR TITLE
more ScannedTypehint improvements

### DIFF
--- a/src/definitions/ScannedTypehint.hack
+++ b/src/definitions/ScannedTypehint.hack
@@ -16,6 +16,7 @@ use namespace HH\Lib\{Str, Vec};
 final class ScannedTypehint {
   public function __construct(
     private HHAST\Node $ast,
+    private ?HHAST\ResolvedTypeKind $kind,
     private string $typeName,
     private vec<ScannedTypehint> $generics,
     private bool $nullable,
@@ -27,6 +28,10 @@ final class ScannedTypehint {
 
   public function getAST(): HHAST\Node {
     return $this->ast;
+  }
+
+  public function getKind(): ?HHAST\ResolvedTypeKind {
+    return $this->kind;
   }
 
   public function getTypeName(): string {

--- a/tests/AbstractHackTest.hack
+++ b/tests/AbstractHackTest.hack
@@ -190,7 +190,7 @@ abstract class AbstractHackTest extends Facebook\HackTest\HackTest {
     expect($type?->getGenericTypes())->toBeEmpty();
 
     $type = $this->getFunction('returns_generic')->getReturnType();
-    expect($type?->getTypeName())->toBeSame('Vector');
+    expect($type?->getTypeName())->toBeSame('HH\\Vector');
     $generics = $type?->getGenericTypes();
     expect(count($generics))->toBeSame(1);
     $sub_type = $generics[0] ?? null;
@@ -198,11 +198,11 @@ abstract class AbstractHackTest extends Facebook\HackTest\HackTest {
     expect($sub_type?->getGenericTypes())->toBeEmpty();
 
     $type = $this->getFunction('returns_nested_generic')->getReturnType();
-    expect($type?->getTypeName())->toBeSame('Vector');
+    expect($type?->getTypeName())->toBeSame('HH\\Vector');
     $generics = $type?->getGenericTypes();
     expect(count($generics))->toBeSame(1);
     $sub_type = $generics[0] ?? null;
-    expect($sub_type?->getTypeName())->toBeSame('Vector');
+    expect($sub_type?->getTypeName())->toBeSame('HH\\Vector');
     $sub_generics = $sub_type?->getGenericTypes();
     expect(count($sub_generics))->toBeSame(1);
     $sub_sub_type = $sub_generics[0] ?? null;

--- a/tests/GenericsTest.hack
+++ b/tests/GenericsTest.hack
@@ -150,6 +150,6 @@ class GenericsTest extends \Facebook\HackTest\HackTest {
       $function->getParameters(),
       $param ==> $param->getTypehint()?->getTypeText(),
     );
-    expect($param_types)->toBeSame(vec['ImmMap<string,string>']);
+    expect($param_types)->toBeSame(vec['HH\\ImmMap<string,string>']);
   }
 }

--- a/tests/RelationshipsTest.hack
+++ b/tests/RelationshipsTest.hack
@@ -52,15 +52,15 @@ class RelationshipsTest extends \Facebook\HackTest\HackTest {
   public async function testClassImplementsGenerics(): Awaitable<void> {
     $data = '<?hh class Foo implements KeyedIterable<Tk,Tv> {}';
     $def = (await FileParser::fromDataAsync($data))->getClass('Foo');
-    expect($def->getInterfaceNames())->toBeSame(vec['KeyedIterable']);
+    expect($def->getInterfaceNames())->toBeSame(vec['HH\\KeyedIterable']);
     expect(Vec\map($def->getInterfaceInfo(), $x ==> $x->getTypeText()))
-      ->toBeSame(vec['KeyedIterable<Tk,Tv>']);
+      ->toBeSame(vec['HH\\KeyedIterable<Tk,Tv>']);
   }
 
   public async function testClassImplementsNestedGenerics(): Awaitable<void> {
     $data = '<?hh class VectorIterable<Tv> implements Iterable<vec<Tv>> {}';
     $def = (await FileParser::fromDataAsync($data))->getClass('VectorIterable');
-    expect($def->getInterfaceNames())->toBeSame(vec['Iterable']);
+    expect($def->getInterfaceNames())->toBeSame(vec['HH\\Iterable']);
     expect(
       Vec\map(
         $def->getInterfaceInfo(),
@@ -68,7 +68,7 @@ class RelationshipsTest extends \Facebook\HackTest\HackTest {
       ),
     )->toBeSame(vec[vec['vec']]);
     expect(Vec\map($def->getInterfaceInfo(), $x ==> $x->getTypeText()))
-      ->toBeSame(vec['Iterable<vec<Tv>>']);
+      ->toBeSame(vec['HH\\Iterable<vec<Tv>>']);
   }
 
   public async function testTraitImplements(): Awaitable<void> {

--- a/tests/TypehintTest.hack
+++ b/tests/TypehintTest.hack
@@ -45,7 +45,7 @@ final class TypehintTest extends \Facebook\HackTest\HackTest {
       // Autoimports
       tuple('void', 'void', 'void'),
       tuple('dict<int, string>', 'dict', 'dict<int,string>'),
-      tuple('Vector<string>', 'Vector', 'Vector<string>'),
+      tuple('Vector<string>', 'HH\\Vector', 'HH\\Vector<string>'),
       tuple('callable', 'callable', 'callable'),
 
       // Special


### PR DESCRIPTION
NOTE: Only review the 2nd commit here (https://github.com/hhvm/definition-finder/pull/23/commits/29a5cfd6ba60bc815b198a7a5cd8f2994773aac5). The first commit is the same as https://github.com/hhvm/definition-finder/pull/22/

- adding getKind() so that callers can distinguish generic types and not
  end up with things like https://docs.hhvm.com/hsl/reference/function/HH.Lib.Keyset.union/
- fixing a bug where we wouldn't call type_resolve() on the classname of
  any typehint with generics (this causes all the HH\ added in tests)