### PR TITLE
add fancy arguments to getTypeText()

### DIFF
--- a/src/definitions/ScannedTypehint.hack
+++ b/src/definitions/ScannedTypehint.hack
@@ -9,28 +9,28 @@
 
 namespace Facebook\DefinitionFinder;
 
-use namespace Facebook\HHAST;
 use namespace HH\Lib\{Str, Vec};
+use type Facebook\HHAST\{InoutToken, Node, ResolvedTypeKind};
 
 /** Represents a parameter, property, constant, or return type hint */
 final class ScannedTypehint {
   public function __construct(
-    private HHAST\Node $ast,
-    private ?HHAST\ResolvedTypeKind $kind,
+    private Node $ast,
+    private ?ResolvedTypeKind $kind,
     private string $typeName,
     private vec<ScannedTypehint> $generics,
     private bool $nullable,
     private ?vec<ScannedShapeField> $shapeFields,
-    private ?(vec<(?HHAST\InoutToken, ScannedTypehint)>, ScannedTypehint)
+    private ?(vec<(?InoutToken, ScannedTypehint)>, ScannedTypehint)
       $functionTypehints,
   ) {
   }
 
-  public function getAST(): HHAST\Node {
+  public function getAST(): Node {
     return $this->ast;
   }
 
-  public function getKind(): ?HHAST\ResolvedTypeKind {
+  public function getKind(): ?ResolvedTypeKind {
     return $this->kind;
   }
 
@@ -61,7 +61,7 @@ final class ScannedTypehint {
   }
 
   public function getFunctionTypehints(
-  ): ?(vec<(?HHAST\InoutToken, ScannedTypehint)>, ScannedTypehint) {
+  ): ?(vec<(?InoutToken, ScannedTypehint)>, ScannedTypehint) {
     return $this->functionTypehints;
   }
 
@@ -103,15 +103,15 @@ final class ScannedTypehint {
     );
 
     switch ($this->kind) {
-      case HHAST\ResolvedTypeKind::CALLABLE:
-      case HHAST\ResolvedTypeKind::GENERIC_PARAMETER:
+      case ResolvedTypeKind::CALLABLE:
+      case ResolvedTypeKind::GENERIC_PARAMETER:
         break;
-      case HHAST\ResolvedTypeKind::QUALIFIED_AUTOIMPORTED_TYPE:
+      case ResolvedTypeKind::QUALIFIED_AUTOIMPORTED_TYPE:
         if ($options & TypeTextOptions::STRIP_AUTOIMPORTED_NAMESPACE) {
           $type_name = Str\strip_prefix($type_name, 'HH\\');
         }
         break;
-      case HHAST\ResolvedTypeKind::QUALIFIED_TYPE:
+      case ResolvedTypeKind::QUALIFIED_TYPE:
         if ($relative_to_namespace !== '') {
           if (Str\starts_with($type_name, $relative_to_namespace.'\\')) {
             $type_name = Str\strip_prefix(
@@ -163,7 +163,7 @@ final class ScannedTypehint {
   private static function getFunctionTypeText(
     string $relative_to_namespace,
     int $options,
-    vec<(?HHAST\InoutToken, ScannedTypehint)> $parameter_types,
+    vec<(?InoutToken, ScannedTypehint)> $parameter_types,
     ScannedTypehint $return_type,
   ): string {
     return Str\format(

--- a/src/definitions/TypeTextOptions.hack
+++ b/src/definitions/TypeTextOptions.hack
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\DefinitionFinder;
+
+/**
+ * Options to customize the output of ScannedTypehint::getTypeText().
+ *
+ * This is meant to be a flags-style enum, all values must be powers of 2.
+ */
+enum TypeTextOptions: int as int {
+  STRIP_AUTOIMPORTED_NAMESPACE = 1;
+}

--- a/tests/AbstractHackTest.hack
+++ b/tests/AbstractHackTest.hack
@@ -191,6 +191,7 @@ abstract class AbstractHackTest extends Facebook\HackTest\HackTest {
 
     $type = $this->getFunction('returns_generic')->getReturnType();
     expect($type?->getTypeName())->toBeSame('HH\\Vector');
+    expect($type?->getTypeName())->toBeSame(Vector::class);
     $generics = $type?->getGenericTypes();
     expect(count($generics))->toBeSame(1);
     $sub_type = $generics[0] ?? null;

--- a/tests/GenericsTest.hack
+++ b/tests/GenericsTest.hack
@@ -151,5 +151,6 @@ class GenericsTest extends \Facebook\HackTest\HackTest {
       $param ==> $param->getTypehint()?->getTypeText(),
     );
     expect($param_types)->toBeSame(vec['HH\\ImmMap<string,string>']);
+    expect($param_types)->toBeSame(vec[ImmMap::class.'<string,string>']);
   }
 }

--- a/tests/NamingTest.hack
+++ b/tests/NamingTest.hack
@@ -216,6 +216,7 @@ class NamingTest extends \Facebook\HackTest\HackTest {
     // since HHVM no longer officially supports PHP.
     expect($php_class->getParentClassName())->toBeSame("HH\\Collection");
     expect($hack_class->getParentClassName())->toBeSame('HH\\Collection');
+    expect($hack_class->getParentClassName())->toBeSame(Collection::class);
   }
 
   public async function testScalarParameterInNamespace(): Awaitable<void> {

--- a/tests/RelationshipsTest.hack
+++ b/tests/RelationshipsTest.hack
@@ -53,6 +53,7 @@ class RelationshipsTest extends \Facebook\HackTest\HackTest {
     $data = '<?hh class Foo implements KeyedIterable<Tk,Tv> {}';
     $def = (await FileParser::fromDataAsync($data))->getClass('Foo');
     expect($def->getInterfaceNames())->toBeSame(vec['HH\\KeyedIterable']);
+    expect($def->getInterfaceNames())->toBeSame(vec[KeyedIterable::class]);
     expect(Vec\map($def->getInterfaceInfo(), $x ==> $x->getTypeText()))
       ->toBeSame(vec['HH\\KeyedIterable<Tk,Tv>']);
   }

--- a/tests/TypehintTest.hack
+++ b/tests/TypehintTest.hack
@@ -46,6 +46,7 @@ final class TypehintTest extends \Facebook\HackTest\HackTest {
       tuple('void', 'void', 'void'),
       tuple('dict<int, string>', 'dict', 'dict<int,string>'),
       tuple('Vector<string>', 'HH\\Vector', 'HH\\Vector<string>'),
+      tuple('Vector<string>', Vector::class, Vector::class.'<string>'),
       tuple('callable', 'callable', 'callable'),
 
       // Special
@@ -133,6 +134,7 @@ final class TypehintTest extends \Facebook\HackTest\HackTest {
   ): vec<(string, string, int, string)> {
     return vec[
       tuple('Vector<int>', '', 0, 'HH\\Vector<int>'),
+      tuple('Vector<int>', '', 0, Vector::class.'<int>'),
       tuple(
         'Vector<int>',
         '',


### PR DESCRIPTION
NOTE: Only review the last commit (https://github.com/hhvm/definition-finder/pull/24/commits/1a6a616f8f7f2d653bb97dced0ba408d41e5efa1), the previous 2 are copies of other PRs.

This replicates the functionality from hh-apidoc, but actually does it correctly.

I'm moving that logic here because otherwise it would be much harder/more confusing to correctly apply the rules at all levels of recursion.