### PR TITLE
improve getTypeText() formatting

### DIFF
--- a/src/definitions/ScannedTypehint.hack
+++ b/src/definitions/ScannedTypehint.hack
@@ -131,7 +131,7 @@ final class ScannedTypehint {
     if ($generics) {
       $sub = $generics
         |> Vec\map($$, $g ==> $g->getTypeText($relative_to_namespace, $options))
-        |> Str\join($$, ',');
+        |> Str\join($$, ', ');
       if ($base === 'tuple') {
         return '('.$sub.')';
       } else if ($base === '?tuple') {
@@ -151,12 +151,12 @@ final class ScannedTypehint {
     return Vec\map(
       $fields,
       $field ==> Str\format(
-        '%s=>%s',
+        '%s => %s',
         $field->getName()->getAST() |> ast_without_trivia($$)->getCode(),
         $field->getValueType()->getTypeText($relative_to_namespace, $options),
       ),
     )
-      |> Str\join($$, ',')
+      |> Str\join($$, ', ')
       |> 'shape('.$$.')';
   }
 
@@ -176,8 +176,8 @@ final class ScannedTypehint {
             $type->getTypeText($relative_to_namespace, $options);
         },
       )
-        |> Str\join($$, ','),
-      ':'.$return_type->getTypeText($relative_to_namespace, $options),
+        |> Str\join($$, ', '),
+      ': '.$return_type->getTypeText($relative_to_namespace, $options),
     );
   }
 }

--- a/tests/FunctionNotDefinitionTest.hack
+++ b/tests/FunctionNotDefinitionTest.hack
@@ -45,7 +45,7 @@ EOF
     $rt = $p->getFunction('foo')->getReturnType();
 
     expect($rt?->getTypeName())->toBeSame('callable');
-    expect($rt?->getTypeText())->toBeSame('(function():void)');
+    expect($rt?->getTypeText())->toBeSame('(function(): void)');
   }
 
   public async function testReturnsGenericCallable(): Awaitable<void> {
@@ -55,7 +55,7 @@ EOF
 
     $rt = $p->getFunction('foo')->getReturnType();
     expect($rt?->getTypeName())->toBeSame('callable');
-    expect($rt?->getTypeText())->toBeSame('(function():vec<string>)');
+    expect($rt?->getTypeText())->toBeSame('(function(): vec<string>)');
   }
 
   public async function testAsParameterType(): Awaitable<void> {

--- a/tests/GenericsTest.hack
+++ b/tests/GenericsTest.hack
@@ -150,7 +150,7 @@ class GenericsTest extends \Facebook\HackTest\HackTest {
       $function->getParameters(),
       $param ==> $param->getTypehint()?->getTypeText(),
     );
-    expect($param_types)->toBeSame(vec['HH\\ImmMap<string,string>']);
-    expect($param_types)->toBeSame(vec[ImmMap::class.'<string,string>']);
+    expect($param_types)->toBeSame(vec['HH\\ImmMap<string, string>']);
+    expect($param_types)->toBeSame(vec[ImmMap::class.'<string, string>']);
   }
 }

--- a/tests/ParametersTest.hack
+++ b/tests/ParametersTest.hack
@@ -282,7 +282,7 @@ final class ParametersTest extends \Facebook\HackTest\HackTest {
     $type = $parser->getFunction('foo')->getParameters()[0]->getTypehint();
 
     expect($type?->getTypeName())->toBeSame('callable');
-    expect($type?->getTypeText())->toBeSame('(function(int):string)');
+    expect($type?->getTypeText())->toBeSame('(function(int): string)');
   }
 
   public async function testEmptyShapeTypehint(): Awaitable<void> {

--- a/tests/RelationshipsTest.hack
+++ b/tests/RelationshipsTest.hack
@@ -55,7 +55,7 @@ class RelationshipsTest extends \Facebook\HackTest\HackTest {
     expect($def->getInterfaceNames())->toBeSame(vec['HH\\KeyedIterable']);
     expect($def->getInterfaceNames())->toBeSame(vec[KeyedIterable::class]);
     expect(Vec\map($def->getInterfaceInfo(), $x ==> $x->getTypeText()))
-      ->toBeSame(vec['HH\\KeyedIterable<Tk,Tv>']);
+      ->toBeSame(vec['HH\\KeyedIterable<Tk, Tv>']);
   }
 
   public async function testClassImplementsNestedGenerics(): Awaitable<void> {

--- a/tests/TypehintTest.hack
+++ b/tests/TypehintTest.hack
@@ -17,34 +17,34 @@ final class TypehintTest extends \Facebook\HackTest\HackTest {
   public function provideTypesInNamespace(): array<(string, string, string)> {
     return [
       // Unusual syntax
-      tuple('shape("foo" => string)', 'shape', 'shape("foo"=>string)'),
-      tuple('(string, string)', 'tuple', '(string,string)'),
-      tuple('(string, string,)', 'tuple', '(string,string)'),
-      tuple('(function(): void)', 'callable', '(function():void)'),
-      tuple('(function(string,): int)', 'callable', '(function(string):int)'),
+      tuple('shape("foo" => string)', 'shape', 'shape("foo" => string)'),
+      tuple('(string, string)', 'tuple', '(string, string)'),
+      tuple('(string, string,)', 'tuple', '(string, string)'),
+      tuple('(function(): void)', 'callable', '(function(): void)'),
+      tuple('(function(string,): int)', 'callable', '(function(string): int)'),
       tuple(
         '(function(a,b): int)',
         'callable',
-        '(function(MyNamespace\\a,MyNamespace\\b):int)',
+        '(function(MyNamespace\\a, MyNamespace\\b): int)',
       ),
 
       // Shape with a namespaced field
       tuple(
         'shape("foo" => string, "bar" => Baz)',
         'shape',
-        'shape("foo"=>string,"bar"=>MyNamespace\\Baz)',
+        'shape("foo" => string, "bar" => MyNamespace\\Baz)',
       ),
 
       // Function with an inout param
       tuple(
         '(function(inout Foo): Bar)',
         'callable',
-        '(function(inout MyNamespace\\Foo):MyNamespace\\Bar)',
+        '(function(inout MyNamespace\\Foo): MyNamespace\\Bar)',
       ),
 
       // Autoimports
       tuple('void', 'void', 'void'),
-      tuple('dict<int, string>', 'dict', 'dict<int,string>'),
+      tuple('dict<int, string>', 'dict', 'dict<int, string>'),
       tuple('Vector<string>', 'HH\\Vector', 'HH\\Vector<string>'),
       tuple('Vector<string>', Vector::class, Vector::class.'<string>'),
       tuple('callable', 'callable', 'callable'),
@@ -64,15 +64,19 @@ final class TypehintTest extends \Facebook\HackTest\HackTest {
 
       // Nullables
       tuple('?Foo', 'MyNamespace\\Foo', '?MyNamespace\\Foo'),
-      tuple('?dict<int, string>', 'dict', '?dict<int,string>'),
-      tuple('?shape("foo" => string)', 'shape', '?shape("foo"=>string)'),
-      tuple('?(string, string)', 'tuple', '?(string,string)'),
-      tuple('?(function(): void)', 'callable', '?(function():void)'),
-      tuple('?(function(string,): int)', 'callable', '?(function(string):int)'),
+      tuple('?dict<int, string>', 'dict', '?dict<int, string>'),
+      tuple('?shape("foo" => string)', 'shape', '?shape("foo" => string)'),
+      tuple('?(string, string)', 'tuple', '?(string, string)'),
+      tuple('?(function(): void)', 'callable', '?(function(): void)'),
+      tuple(
+        '?(function(string,): int)',
+        'callable',
+        '?(function(string): int)',
+      ),
       tuple(
         '?(function(a,b): int)',
         'callable',
-        '?(function(MyNamespace\\a,MyNamespace\\b):int)',
+        '?(function(MyNamespace\\a, MyNamespace\\b): int)',
       ),
     ];
   }
@@ -100,17 +104,27 @@ final class TypehintTest extends \Facebook\HackTest\HackTest {
     return [
       tuple('Foo', false, 'Foo', 'Foo'),
       tuple('?Foo', true, 'Foo', '?Foo'),
-      tuple('(function():?string)', false, 'callable', '(function():?string)'),
-      tuple('?(function():?string)', true, 'callable', '?(function():?string)'),
-      tuple('shape("foo" => ?string)', false, 'shape', 'shape("foo"=>?string)'),
+      tuple('(function():?string)', false, 'callable', '(function(): ?string)'),
+      tuple(
+        '?(function():?string)',
+        true,
+        'callable',
+        '?(function(): ?string)',
+      ),
+      tuple(
+        'shape("foo" => ?string)',
+        false,
+        'shape',
+        'shape("foo" => ?string)',
+      ),
       tuple(
         '?shape("foo" => ?string)',
         true,
         'shape',
-        '?shape("foo"=>?string)',
+        '?shape("foo" => ?string)',
       ),
-      tuple('(?string, string)', false, 'tuple', '(?string,string)'),
-      tuple('?(?string, string)', true, 'tuple', '?(?string,string)'),
+      tuple('(?string, string)', false, 'tuple', '(?string, string)'),
+      tuple('?(?string, string)', true, 'tuple', '?(?string, string)'),
     ];
   }
 
@@ -202,7 +216,7 @@ final class TypehintTest extends \Facebook\HackTest\HackTest {
   ): Awaitable<void> {
     // Provided typehint is nested inside a function inside a shape inside a
     // generic type, to verify that all rules are correctly applied recursively.
-    $prefix = 'vec<shape(\'field\'=>(function():';
+    $prefix = 'vec<shape(\'field\' => (function(): ';
     $suffix = '))>';
     $code = '
       namespace Foo\\Bar;


### PR DESCRIPTION
Previously we'd just dump the "AST without trivia", so there are no spaces between anything.

This adds spaces where people (and hackfmt) normally put them.

I don't think anyone depends on the old formatting, but if there's a chance of that, I can instead make this an option (we already have the `$options` argument for those anyway).