### PR TITLE
unbreak XHPTest

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,4 +1,4 @@
-ignored_paths = [ "vendor/.+/tests/.+", "tests/data/.+" ]
+ignored_paths = [ "vendor/.+/tests/.+" ]
 assume_php=false
 disallow_elvis_space=true
 disallow_non_arraykey_keys=true

--- a/tests/AttributesTest.hack
+++ b/tests/AttributesTest.hack
@@ -57,7 +57,7 @@ class AttributesTest extends \Facebook\HackTest\HackTest {
 
   public async function testWithFormattedArrayAttribute(): Awaitable<void> {
     $class = $this->findClass('ClassWithFormattedArrayAttribute');
-    expect($class->getAttributes())->toBeSame(dict['Bar' => vec[varray['herp']]]);
+    expect($class->getAttributes())->toBeSame(dict['Bar' => vec[vec['herp']]]);
   }
 
   public async function testWithSingleIntAttribute(): Awaitable<void> {

--- a/tests/XHPTest.hack
+++ b/tests/XHPTest.hack
@@ -66,10 +66,19 @@ EOF;
   }
 
   public async function testXHPClassNamesAreCorrect(): Awaitable<void> {
-    $parser = await FileParser::fromDataAsync('<?hh class :foo:bar:baz:herp-derp {}');
-
+    // must be the same namespace as this test, otherwise the ::class literal
+    // below resolves to a differently namespaced name (except on older versions
+    // of HHVM which don't handle namespaced XHP classes correctly)
+    $parser = await FileParser::fromDataAsync('
+      namespace Facebook\DefinitionFinder\Test {
+        class :foo:bar:baz:herp-derp {}
+      }
+    ');
     expect(C\onlyx($parser->getClassNames()))->toContainSubstring(
-      /* HH_FIXME[2049] */ :foo:bar:baz:herp-derp::class,
+      :foo:bar:baz:herp-derp::class,
     );
   }
 }
+
+// This is here so that we can use a ::class literal above without FIXMEs.
+final class :foo:bar:baz:herp-derp {}

--- a/tests/XHPTest.hack
+++ b/tests/XHPTest.hack
@@ -66,19 +66,9 @@ EOF;
   }
 
   public async function testXHPClassNamesAreCorrect(): Awaitable<void> {
-    // must be the same namespace as this test, otherwise the ::class literal
-    // below resolves to a differently namespaced name (except on older versions
-    // of HHVM which don't handle namespaced XHP classes correctly)
-    $parser = await FileParser::fromDataAsync('
-      namespace Facebook\DefinitionFinder\Test {
-        class :foo:bar:baz:herp-derp {}
-      }
-    ');
+    $parser = await FileParser::fromFileAsync(__DIR__.'/data/xhp.hack');
     expect(C\onlyx($parser->getClassNames()))->toContainSubstring(
-      :foo:bar:baz:herp-derp::class,
+      \facebook_definition_finder_test_xhp_class_for_classname()
     );
   }
 }
-
-// This is here so that we can use a ::class literal above without FIXMEs.
-final class :foo:bar:baz:herp-derp {}

--- a/tests/data/attributes.php
+++ b/tests/data/attributes.php
@@ -43,7 +43,18 @@ class ClassWithFormattedAttributes {}
 
 <<
 Bar(
-  ['herp']
+  vec['herp']
 )
 >>
 class ClassWithFormattedArrayAttribute {}
+
+// declarations for the test attributes used above
+abstract class TestAttribute {
+  public function __construct(mixed $a = null, mixed $b = null) {}
+}
+final class Foo extends TestAttribute implements \HH\ClassAttribute {}
+final class Bar extends TestAttribute implements \HH\ClassAttribute {}
+final class Herp extends TestAttribute implements \HH\ClassAttribute {}
+final class ClassFoo extends TestAttribute implements \HH\ClassAttribute {}
+final class FunctionFoo extends TestAttribute implements \HH\FunctionAttribute {
+}

--- a/tests/data/class_properties.php
+++ b/tests/data/class_properties.php
@@ -8,7 +8,7 @@
  *
  */
 
-namespace Facebook\DefinitionFinder\Test;
+namespace Facebook\DefinitionFinder\Test {
 
 class ClassWithProperties {
   private bool $foo = true;
@@ -18,6 +18,8 @@ class ClassWithProperties {
   public function varsArentProps(): void {
     $local = 'test';
   }
+}
+
 }
 
 namespace Facebook\DefinitionFinder\Test2 {

--- a/tests/data/doc_comments.php
+++ b/tests/data/doc_comments.php
@@ -16,9 +16,9 @@ class ClassWithDocComment {}
 class ClassWithoutDocComment {}
 
 /** function doc */
-function function_with_doc_comment() {}
+function function_with_doc_comment(): void {}
 
-function function_without_doc_comment() {}
+function function_without_doc_comment(): void {}
 
 /** type doc */
 type TypeWithDocComment = string;
@@ -29,4 +29,8 @@ newtype NewtypeWithDocComment = string;
 /** enum doc */
 enum EnumWithDocComment: string {}
 
-function param_with_doc_comment(/** param doc */ $commented, $uncommented) {}
+function param_with_doc_comment(
+  /** param doc */
+  int $commented,
+  string $uncommented,
+): void {}

--- a/tests/data/nested_namespace_hack.php
+++ b/tests/data/nested_namespace_hack.php
@@ -96,7 +96,7 @@ function aliased_no_as(Bar $aliased): Bar {
    return $aliased;
 }
 
-const MY_CONST = 456;
+const /* HH_IGNORE_ERROR[2001] intentional for testing */ MY_CONST = 456;
 const int MY_TYPED_CONST = 123;
 
 type MyType = int;

--- a/tests/data/no_namespace_hack.php
+++ b/tests/data/no_namespace_hack.php
@@ -94,7 +94,7 @@ function aliased_no_as(Bar $aliased): Bar {
    return $aliased;
 }
 
-const MY_CONST = 456;
+const /* HH_IGNORE_ERROR[2001] intentional for testing */ MY_CONST = 456;
 const int MY_TYPED_CONST = 123;
 
 type MyType = int;

--- a/tests/data/single_namespace_hack.php
+++ b/tests/data/single_namespace_hack.php
@@ -96,7 +96,7 @@ function aliased_no_as(Bar $aliased): Bar {
    return $aliased;
 }
 
-const MY_CONST = 456;
+const /* HH_IGNORE_ERROR[2001] intentional for testing */ MY_CONST = 456;
 const int MY_TYPED_CONST = 123;
 
 type MyType = int;

--- a/tests/data/xhp.hack
+++ b/tests/data/xhp.hack
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// in root namespace because namespaced XHP classes are not supported yet
+namespace {
+
+final class :facebook:definition-finder:test:xhp-class-for-classname {
+}
+
+function facebook_definition_finder_test_xhp_class_for_classname(
+): classname<mixed> {
+  return :facebook:definition-finder:test:xhp-class-for-classname::class;
+}
+
+}


### PR DESCRIPTION
This test started failing on nightly builds because `:foo:bar:baz:herp-derp::class` now apparently resolves to a correctly namespaced name (an improvement!).