### PR TITLE
update for new XHP flag defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.29-latest
+- HHVM_VERSION=4.73-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly
 install:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   },
   "require": {
-    "hhvm": "^4.29",
+    "hhvm": "^4.73",
     "hhvm/hhvm-autoload": "^2.0|^3.0",
     "hhvm/hsl": "^4.0",
     "hhvm/type-assert": "^3.2|^4.0",

--- a/src/consumers/mangle_xhp_name_token.hack
+++ b/src/consumers/mangle_xhp_name_token.hack
@@ -15,8 +15,7 @@ use namespace HH\Lib\Str;
 function mangle_xhp_name_token(
   HHAST\XHPClassNameToken $token,
 ): string {
-  return $token->getText()
-    |> Str\strip_prefix($$, ':')
-    |> Str\replace_every($$, dict[':' => '__', '-' => '_'])
-    |> 'xhp_'.$$;
+  // With disable_xhp_element_mangling=true (default), the only required change
+  // is the namespace separator.
+  return Str\replace($token->getText(), ':', '\\');
 }

--- a/tests/AbstractHackTest.hack
+++ b/tests/AbstractHackTest.hack
@@ -39,8 +39,8 @@ abstract class AbstractHackTest extends Facebook\HackTest\HackTest {
         $this->getPrefix().'GenericAliasedConstraintClass',
         $this->getPrefix().'AbstractFinalClass',
         $this->getPrefix().'AbstractClass',
-        $this->getPrefix().'xhp_foo',
-        $this->getPrefix().'xhp_foo__bar',
+        $this->getPrefix().'herp',
+        $this->getPrefix().'herp\\derp',
       ],
     );
   }

--- a/tests/XHPTest.hack
+++ b/tests/XHPTest.hack
@@ -15,46 +15,36 @@ use namespace HH\Lib\C;
 
 final class XHPTest extends \Facebook\HackTest\HackTest {
   public async function testXHPRootClass(): Awaitable<void> {
-    $data = '<?hh class :foo:bar {}';
+    $data = '<?hh xhp class foo:bar {}';
 
     $parser = await FileParser::fromDataAsync($data);
-    expect($parser->getClassNames())->toContain('xhp_foo__bar');
-  }
-
-  public async function testNullableXHPReturn(): Awaitable<void> {
-    $data = '<?hh function foo(): ?:foo:bar {}';
-    $parser = await FileParser::fromDataAsync($data);
-    $function = $parser->getFunction('foo');
-    $ret = $function->getReturnType();
-    $ret = expect($ret)->toNotBeNull();
-    expect($ret->getTypeName())->toBeSame('xhp_foo__bar');
-    expect($ret->isNullable())->toBeTrue();
+    expect($parser->getClassNames())->toContain('foo\\bar');
   }
 
   public async function testXHPClassWithParent(): Awaitable<void> {
-    $data = '<?hh class :foo:bar extends :herp:derp {}';
+    $data = '<?hh xhp class foo:bar extends herp\\derp {}';
 
     $parser = await FileParser::fromDataAsync($data);
-    expect($parser->getClassNames())->toContain('xhp_foo__bar');
+    expect($parser->getClassNames())->toContain('foo\\bar');
 
-    expect($parser->getClass('xhp_foo__bar')->getParentClassName())->toBeSame(
-      'xhp_herp__derp',
+    expect($parser->getClass('foo\\bar')->getParentClassName())->toBeSame(
+      'herp\\derp',
     );
   }
 
   public async function testXHPEnumAttributeParses(): Awaitable<void> {
     // XHP Attributes are not reported, but shouldn't cause parse errors
     $data =
-      '<?hh class :foo:bar { attribute enum { "herp", "derp" } myattr @required; }';
+      '<?hh xhp class foo:bar { attribute enum { "herp", "derp" } myattr @required; }';
 
     $parser = await FileParser::fromDataAsync($data);
-    expect($parser->getClassNames())->toContain('xhp_foo__bar');
+    expect($parser->getClassNames())->toContain('foo\\bar');
   }
 
   public async function testXHPEnumAttributesParse(): Awaitable<void> {
     // StatementConsumer was getting confused by the brace
     $data = <<<EOF
-<?hh class :example {
+<?hh xhp class example {
   attribute
     enum { "foo", "bar" } myattr @required,
     enum { "herp", "derp" } myattr2 @required;
@@ -62,7 +52,7 @@ final class XHPTest extends \Facebook\HackTest\HackTest {
 EOF;
 
     $parser = await FileParser::fromDataAsync($data);
-    expect($parser->getClassNames())->toContain('xhp_example');
+    expect($parser->getClassNames())->toContain('example');
   }
 
   public async function testXHPClassNamesAreCorrect(): Awaitable<void> {

--- a/tests/data/nested_namespace_hack.php
+++ b/tests/data/nested_namespace_hack.php
@@ -47,10 +47,10 @@ abstract class AbstractClass {
   abstract public function iAmAlsoNotAGlobalFunction(): void;
 }
 
-class :foo {
+xhp class herp {
 }
 
-class :foo:bar {
+xhp class herp:derp {
 }
 
 function simple_function(): void {

--- a/tests/data/no_namespace_hack.php
+++ b/tests/data/no_namespace_hack.php
@@ -45,10 +45,10 @@ abstract class AbstractClass {
   abstract public function iAmAlsoNotAGlobalFunction(): void;
 }
 
-class :foo {
+xhp class herp {
 }
 
-class :foo:bar {
+xhp class herp:derp {
 }
 
 function simple_function(): void {

--- a/tests/data/single_namespace_hack.php
+++ b/tests/data/single_namespace_hack.php
@@ -47,10 +47,10 @@ abstract class AbstractClass {
   abstract public function iAmAlsoNotAGlobalFunction(): void;
 }
 
-class :foo {
+xhp class herp {
 }
 
-class :foo:bar {
+xhp class herp:derp {
 }
 
 function simple_function(): void {

--- a/tests/data/xhp.hack
+++ b/tests/data/xhp.hack
@@ -7,15 +7,16 @@
  *
  */
 
-// in root namespace because namespaced XHP classes are not supported yet
+namespace Facebook\DefinitionFinder {
+  // For historical reasons, the new `xhp class` syntax allows declaring any
+  // part of the namespace inside the class name.
+  final xhp class test:xhp_class_for_classname {
+  }
+}
+
 namespace {
-
-final class :facebook:definition-finder:test:xhp-class-for-classname {
-}
-
-function facebook_definition_finder_test_xhp_class_for_classname(
-): classname<mixed> {
-  return :facebook:definition-finder:test:xhp-class-for-classname::class;
-}
-
+  function facebook_definition_finder_test_xhp_class_for_classname(
+  ): classname<mixed> {
+    return Facebook\DefinitionFinder\test\xhp_class_for_classname::class;
+  }
 }


### PR DESCRIPTION
This could also be updated to handle all combinations of flags (like https://github.com/hhvm/hhvm-autoload/pull/56) but given that this project isn't as critical as hhvm-autoload, it's perhaps better to keep it simple instead of adding all those edge cases...