### PR TITLE
support union/intersection typehints

### DIFF
--- a/src/consumers/typehint_from_ast.hack
+++ b/src/consumers/typehint_from_ast.hack
@@ -237,6 +237,28 @@ function typehint_from_ast(
       null,
     );
   }
+  if ($node is HHAST\UnionTypeSpecifier) {
+    return new ScannedTypehint(
+      $node,
+      null,
+      ScannedTypehint::UNION,
+      typehints_from_ast($context, $node->getTypes() as HHAST\NodeList<_>),
+      false,
+      null,
+      null,
+    );
+  }
+  if ($node is HHAST\IntersectionTypeSpecifier) {
+    return new ScannedTypehint(
+      $node,
+      null,
+      ScannedTypehint::INTERSECTION,
+      typehints_from_ast($context, $node->getTypes() as HHAST\NodeList<_>),
+      false,
+      null,
+      null,
+    );
+  }
   if ($node is HHAST\ListItem<_>) {
     return typehint_from_ast($context, $node->getItem());
   }

--- a/tests/UnionIntersectionTypeHintsTest.hack
+++ b/tests/UnionIntersectionTypeHintsTest.hack
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\DefinitionFinder\Test;
+
+use namespace HH\Lib\{C, Str, Vec};
+use type Facebook\HackTest\{DataProvider, HackTest};
+use type Facebook\DefinitionFinder\{FileParser, ScannedTypehint};
+use function Facebook\FBExpect\expect;
+
+final class UnionIntersectionTypeHintsTest extends HackTest {
+
+  private static ?dict<string, ScannedTypehint> $allParams;
+
+  <<__Override>>
+  public static async function beforeFirstTestAsync(): Awaitable<void> {
+    $parser = await FileParser::fromFileAsync(
+      __DIR__.'/data/union_intersection_type_hints.hhi',
+    );
+    $params = dict[];
+    foreach ($parser->getFunctions() as $function) {
+      $params[$function->getShortName()] =
+        C\onlyx($function->getParameters())->getTypehint() as nonnull;
+    }
+    self::$allParams = $params;
+  }
+
+  public static function provider(
+  ): vec<(string, string, bool, string)> {
+    $ns = 'Facebook\DefinitionFinder\Test';
+    return vec[
+      tuple('intersection', ScannedTypehint::INTERSECTION, false, '(I & J)'),
+      tuple('union', ScannedTypehint::UNION, false, '(I | J)'),
+      tuple('nullable_inter', ScannedTypehint::INTERSECTION, true, '?(I & J)'),
+      tuple('nullable_union', ScannedTypehint::UNION, true, '?(I | J)'),
+      tuple('complex', ScannedTypehint::INTERSECTION, false, '(I & ?(?J | K))'),
+    ]
+      |> Vec\map(
+        $$,
+        $testcase ==> {
+          $testcase[3] = Str\replace_every(
+            $testcase[3],
+            dict['I' => $ns.'\\I', 'J' => $ns.'\\J', 'K' => $ns.'\\K'],
+          );
+          return $testcase;
+        },
+      );
+  }
+
+  <<DataProvider('provider')>>
+  public async function test(
+    string $function_name,
+    string $expected_type_name,
+    bool $expected_nullable,
+    string $expected_type_text,
+  ): Awaitable<void> {
+    $type = self::$allParams as nonnull[$function_name];
+    expect($type->getTypeName())->toEqual($expected_type_name);
+    expect($type->isNullable())->toEqual($expected_nullable);
+    expect($type->getTypeText())->toEqual($expected_type_text);
+  }
+}

--- a/tests/data/union_intersection_type_hints.hhi
+++ b/tests/data/union_intersection_type_hints.hhi
@@ -1,0 +1,23 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+<<file: __EnableUnstableFeatures('union_intersection_type_hints')>>
+
+namespace Facebook\DefinitionFinder\Test;
+
+interface I {}
+interface J {}
+interface K {}
+
+function intersection((I & J) $_x): void {}
+function union((I | J) $_x): void {}
+function nullable_inter(?(I & J) $_x): void {}
+function nullable_union(?(I | J) $_x): void {}
+function complex((I & ?(?J | K)) $_x): void {}


### PR DESCRIPTION
These are starting to [show up](https://github.com/facebook/hhvm/search?q=%3C%3Cfile%3A__EnableUnstableFeatures%28%27union_intersection_type_hints%27%29%3E%3E) in HHVM's built-in .hhi files, so we need to support them in order to update docs.hhvm.com to the latest HHVM version.