### PR TITLE
Fix some lints reported by CI on HHVM latest

### DIFF
--- a/src/expression/StaticDictExpression.hack
+++ b/src/expression/StaticDictExpression.hack
@@ -21,7 +21,7 @@ final class StaticDictExpression extends Expression<dict<arraykey, mixed>> {
   ): ?Expression<dict<arraykey, mixed>> {
     return Vec\map(
       $node->getMembers()?->getChildrenOfItemsOfType(HHAST\Node::class) ?? vec[],
-      $m ==> StaticElementInitializerExpression::match($m),
+      StaticElementInitializerExpression::match<>,
     )
       |> Vec\filter_nulls($$)
       |> Vec\map($$, $e ==> $e->getValue())

--- a/src/expression/StaticListExpression.hack
+++ b/src/expression/StaticListExpression.hack
@@ -20,7 +20,7 @@ final class StaticListExpression extends Expression<vec<mixed>> {
   ): ?Expression<vec<mixed>> {
     $items = Vec\map(
       $n->getChildrenOfItems(),
-      $item ==> StaticExpression::match($item),
+      StaticExpression::match<>,
     );
     $out = vec[];
     foreach ($items as $item) {


### PR DESCRIPTION
Our CI was reporting a number of "You have made a lambda which forwards all its arguments to a static method or function." lints on HHVM latest. Apply the changes suggested by the linter.