### PR TITLE
Support and require hhvm and hhast 4.157

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.102'
+          - '4.157'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     }
   },
   "require": {
-    "hhvm": "^4.102",
+    "hhvm": "^4.157",
     "hhvm/hhvm-autoload": "^2.0|^3.0",
     "hhvm/hsl": "^4.0",
     "hhvm/type-assert": "^3.2|^4.0",
-    "hhvm/hhast": "^4.21.4"
+    "hhvm/hhast": "^4.157"
   },
   "require-dev": {
     "facebook/fbexpect": "^2.6.1",

--- a/src/consumers/type_constant_from_ast.hack
+++ b/src/consumers/type_constant_from_ast.hack
@@ -20,6 +20,14 @@ function type_constant_from_ast(
     $node->getModifiers()?->getChildren() ?? vec[],
     $t ==> $t is HHAST\AbstractToken,
   );
+  if ($is_abstract) {
+    // multiple type constraints are supported at the syntax level
+    // but they do not typecheck yet; grab the first one for now
+    $constraints = $node->getTypeConstraints()?->getChildren() ?? vec[];
+    $typehint = C\first($constraints)?->getType();
+  } else {
+    $typehint = $node->getTypeSpecifier();
+  }
   return (
     new ScannedTypeConstant(
       $node,
@@ -28,9 +36,7 @@ function type_constant_from_ast(
       /* docblock = */ null,
       typehint_from_ast(
         $context,
-        $is_abstract
-          ? $node->getTypeConstraint()?->getType()
-          : $node->getTypeSpecifier(),
+        $typehint,
       ),
       $is_abstract
         ? AbstractnessToken::IS_ABSTRACT


### PR DESCRIPTION
With the release of hhvm 4.157 and hhast 4.157 type constants can now
have more than one type constraint, but so far only at the syntax
level (it won't typecheck). Add minimal support for this by grabbing
the first constraint if it exists (for now). We will need further
changes once the feature is fully launched.

Tested locally with:
```
hh_client
vendor/bin/hacktest tests
```